### PR TITLE
Add refactoring guidance for dienstbeta

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,5 +11,10 @@
 ## Tests und Validierung
 - Dokumentiere im Pull-Request alle manuell ausgeführten Tests oder Skripte. Falls keine Tests existieren, erkläre kurz, wie du die Funktionalität geprüft hast.
 
+## Architektur-Notizen
+- Vorschläge zur Aufteilung und Teststrategie für `dienstbeta.gs` stehen in `docs/REFAKTORIERUNG.md`. Bitte dortige Hinweise prüfen, bevor umfangreiche Änderungen am Dienstplan-Algorithmus erfolgen.
+- Bei Arbeiten an Google-Apps-Script-Dateien bevorzugt mehrere kleinere `.gs`-Dateien gemäß der empfohlenen Struktur anlegen, damit Menüs, Blattverwaltung und Planungslogik getrennt bleiben.
+- Extrahiere neue, reine Hilfsfunktionen nach Möglichkeit in Utility-Dateien, um sie mit Node-basierten Tests abdecken zu können (z.B. via `jest` oder `vitest` in Verbindung mit `gas-local`).
+
 ## PR-Beschreibung
 - Die PR-Zusammenfassung soll zwei Abschnitte enthalten: "Änderungen" (Stichpunkte) und "Tests" (Stichpunkte mit den ausgeführten Befehlen oder "keine").

--- a/dienstbeta.gs
+++ b/dienstbeta.gs
@@ -1,11 +1,6 @@
 ﻿/**
- * die übergeordneten Steuerungsfunktionen.
- * Version 12: Konsolidiert, entfernt redundante Hilfsfunktionen.
- * Fügt eine Funktion zum Erstellen einer Sicherheitskopie der gesamten Tabelle hinzu.
- * Fügt eine Funktion zum automatischen Anordnen der Blätter hinzu.
- * Verschiebt "Blätter anordnen" direkt ins Hauptmenü.
- * Automatisiert die Blattsortierung nach dem Anlegen der zukünftigen Blätter.
- * Automatisiert die Erstellung von Sicherheitskopien am 1. und 10. jedes Monats.
+ * Zentrale Steuerungsfunktionen für den Dienstplan.
+ * Hinweise zur geplanten Aufteilung und Teststrategie: siehe docs/REFAKTORIERUNG.md.
  */
 
 // Globale Konstanten für die Blattnamen und Konfigurationen

--- a/docs/REFAKTORIERUNG.md
+++ b/docs/REFAKTORIERUNG.md
@@ -1,0 +1,49 @@
+# Refaktorierungsempfehlungen für `dienstbeta.gs`
+
+## Ausgangslage
+- Die Datei `dienstbeta.gs` umfasst weit über 2000 Zeilen und vereint Menüsteuerung, Datenaufbereitung, Trigger-Verwaltung und die eigentliche Planungslogik in einer Datei.
+- Unterschiedliche Verantwortlichkeiten teilen sich globale Zustände (z.B. `SpreadsheetApp`, Konfigurationskonstanten, Statusobjekte der Planberechnung), wodurch Änderungen schwer nachvollziehbar werden.
+- Reine Hilfsfunktionen wie `diffInDays` oder `computeRelativeDayIndex` stehen unmittelbar neben Trigger-Funktionen wie `onOpen` sowie komplexen Algorithmen wie `distributeMainDuties` oder `balanceMainDuties`.
+
+## Sinnvolle Aufteilung in mehrere Dateien
+1. **Grundlagen & Utilities**
+   - `constants.gs`: Enthält `CONSTANTS`, `DUTY_RULES`, `MS_PER_DAY` sowie zukünftig weitere Konfigurationsobjekte.
+   - `date-utils.gs`: Kapselt Datumshilfen (`normalizeDate`, `diffInDays`, `computeRelativeDayIndex`, `getPreviousYearMonth`).
+   - `logging.gs` (optional): Gemeinsame Fehlerbehandlung (`handleError`) und wiederkehrende Logik wie `isTriggered`.
+
+2. **Benutzeroberfläche & Setup**
+   - `ui.gs`: Menüaufbau (`onOpen`) sowie `onEdit`, damit UI-Ereignisse klar getrennt bleiben.
+   - `setup.gs`: `initialSetup`, `createConfigSheet`, `createDoctorsSheet`, `createJumperListSheet` und weitere Funktionen, die einmalige Tabellenstrukturen erzeugen.
+
+3. **Blattverwaltung & Automatisierung**
+   - `sheet-lifecycle.gs`: `checkAndCreateFutureSheets`, `createPastPlanSheet`, `createMonthlyPlanSheet`, `cleanupOldSheets`, `arrangeSheets`, `createPlanLayout`, `createSpreadsheetBackup`.
+   - `automation.gs`: Trigger (`setupAutomationTriggers`, `deleteAllTriggers`, `generateFutureMonthlyPlan`) und Hilfsfunktionen wie `isTriggered`.
+
+4. **Planungsdaten & Algorithmen**
+   - `planning/data-loader.gs`: `getPlanningData`, `loadRecentHistoryFromPreviousMonth`, `calculateDutyTargets`, `buildAvailabilityMatrix`, `getHolidaysForYear`, `updateJumperList`.
+   - `planning/main-duties.gs`: `distributeMainDuties` plus zugehörige Helfer (`categorizeDoctorsForMainDuty`, `updateStatsForNewAssignment`, `updateStatsForSwap`, `recomputeLastMainDutyDate`, `chooseBestDoctor`, etc.).
+   - `planning/late-duties.gs`: `distributeLateShifts`, `categorizeDoctorsForLateShift`, `violatesLateShiftFollowUpRule`.
+   - `planning/output.gs`: `writePlanToSheet` und Hilfsfunktionen, die ausschließlich für die Ausgabe zuständig sind.
+
+Durch diese Struktur verbleiben pro Datei überschaubare Verantwortlichkeiten; zudem lassen sich reine Datenfunktionen deutlich leichter testen.
+
+## Strategien zur Testbarkeit
+- **Extrahiere pure Funktionen**: Funktionen wie `calculateDutyTargets`, `categorizeDoctorsForMainDuty` oder `buildAvailabilityMatrix` können nach der Aufteilung ohne direkte Abhängigkeit zu Apps Script in Node-Tests geprüft werden.
+- **Lokale Testumgebung**: Richte ein `package.json` ein und nutze `clasp` plus `@types/google-apps-script`, um die Skripte lokal zu synchronisieren. Für Tests eignen sich `jest` oder `vitest` in Verbindung mit Bibliotheken wie [`gas-local`](https://github.com/google/clasp/tree/master/packages/gas-local) oder [`google-apps-script-mock`](https://github.com/PopGoesTheWza/google-apps-script-mock), um `SpreadsheetApp` & Co. zu simulieren.
+- **Testschwerpunkte**:
+  - Datumshilfsfunktionen (korrekte Normalisierung, Monatswechsel).
+  - Berechnung der Soll-Dienstzahlen (`calculateDutyTargets`).
+  - Auswahlheuristiken (`chooseBestDoctor`, `categorizeDoctorsForLateShift`).
+  - Verarbeitung der Einspringerliste (`updateJumperList`).
+- **Integrationstests**: Erstelle Sample-Daten (kleines Spreadsheet in JSON-Form) und speise sie in `getPlanningData` bzw. den Planungsfluss, während `SpreadsheetApp` durch Mocks ersetzt wird. So lässt sich die gesamte Kette bis `writePlanToSheet` prüfen, ohne Google Drive aufzurufen.
+
+## Isolierung der Funktionalität
+- Führe ein `SpreadsheetService`-Interface ein, das nur die benötigten Methoden (`getSheetByName`, `toast`, `getUi`, …) anbietet. Für Tests kann eine einfache In-Memory-Implementierung verwendet werden.
+- Lass Datenfunktionen (`getPlanningData`, `loadRecentHistoryFromPreviousMonth`) keine `SpreadsheetApp`-Objekte akzeptieren, sondern das neue Interface. Dadurch bleiben sie unabhängig von der Laufzeitumgebung.
+- Verwende klar definierte Datenstrukturen (z.B. Typdefinitionen in JSDoc) für `planningData`, damit beim Refactoring schneller sichtbar wird, welche Felder tatsächlich genutzt werden.
+- Reduziere globale Mutationen: Übergib `planningData.stats` explizit an Funktionen, anstatt es implizit in `planningData` zu verändern. So lassen sich Tests gezielt auf bestimmte Ausschnitte beschränken.
+
+## Nächste Schritte
+- Schrittweise Migration: Beginne mit den Hilfsmodulen (`constants.gs`, `date-utils.gs`), da deren Entkopplung das geringste Risiko birgt.
+- Nach jeder Aufteilung manuelle Rauchtests (Plan generieren, Trigger-Setup) durchführen.
+- Ergänze neue Tests zeitnah, damit spätere größere Umbauten am Planungsalgorithmus auf einer abgesicherten Basis stattfinden.


### PR DESCRIPTION
## Änderungen
- Veralteten Versionskommentar in `dienstbeta.gs` entfernt und auf ein zentrales Refactoring-Dokument verwiesen.
- Neues Dokument `docs/REFAKTORIERUNG.md` ergänzt, das konkrete Aufteilungs-, Test- und Isolationsstrategien für `dienstbeta.gs` beschreibt.
- `AGENTS.md` um Architekturhinweise erweitert, damit zukünftige Beiträge die vorgeschlagene Struktur berücksichtigen.

## Tests
- keine


------
https://chatgpt.com/codex/tasks/task_e_68db0cfed37c8330a1725ffa0faa11a9